### PR TITLE
convert all column name to lower case before storing inside tupple

### DIFF
--- a/jx_mysql/mysql.py
+++ b/jx_mysql/mysql.py
@@ -373,7 +373,7 @@ class MySQL(object):
             self.debug and Log.note("Execute SQL:\n{{sql}}", sql=indent(sql))
             self.cursor.execute(sql)
 
-            columns = tuple([utf8_to_unicode(d[0]) for d in self.cursor.description])
+            columns = tuple([utf8_to_unicode(d[0].lower()) for d in self.cursor.description])
             for r in self.cursor:
                 num += 1
                 _execute(wrap(dict(zip(columns, [utf8_to_unicode(c) for c in r]))))


### PR DESCRIPTION
This solves that issue for us almost @klahnakoski 
However the information schema has changed and https://github.com/mozilla/treeherder/blob/master/tests/extract/test_extract_job.sql also needs to be changes since the information schema has changed
I will do them asap